### PR TITLE
Updated GTStructure to use pointers to items instead of value receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ var music gotree.GTStructure
 music.Name = "5 Minutes Alone"
 
 //Add Music to the Album
-album.Items = append(album.Items, music)
+album.Items = append(album.Items, &music)
 
 //Add Album to the Artist
-artist.Items = append(artist.Items, album)
+artist.Items = append(artist.Items, &album)
 
-gotree.PrintTree(artist)
+gotree.PrintTree(&artist)
 ```
 
 ### Read folder and print tree

--- a/gotree.go
+++ b/gotree.go
@@ -9,10 +9,10 @@ import (
 /*GTStructure Structure to output print */
 type GTStructure struct {
 	Name  string
-	Items []GTStructure
+	Items []*GTStructure
 }
 
-func StringTree(object GTStructure) (result string) {
+func StringTree(object *GTStructure) (result string) {
 	result += object.Name + "\n"
 	var spaces []bool
 	result += stringObjItems(object.Items, spaces)
@@ -37,7 +37,7 @@ func stringLine(name string, spaces []bool, last bool) (result string) {
 	return
 }
 
-func stringObjItems(items []GTStructure, spaces []bool) (result string) {
+func stringObjItems(items []*GTStructure, spaces []bool) (result string) {
 	for i, f := range items {
 		last := (i >= len(items)-1)
 		result += stringLine(f.Name, spaces, last)
@@ -50,14 +50,13 @@ func stringObjItems(items []GTStructure, spaces []bool) (result string) {
 }
 
 /*PrintTree - Print the tree in console */
-func PrintTree(object GTStructure) {
+func PrintTree(object *GTStructure) {
 	fmt.Println(StringTree(object))
 }
 
 /*ReadFolder - Read a folder and return the generated object */
-func ReadFolder(directory string) GTStructure {
-
-	var parent GTStructure
+func ReadFolder(directory string) *GTStructure {
+	parent := &GTStructure{}
 
 	parent.Name = directory
 	parent.Items = createGTReadFolder(directory)
@@ -65,14 +64,12 @@ func ReadFolder(directory string) GTStructure {
 	return parent
 }
 
-func createGTReadFolder(directory string) []GTStructure {
-
-	var items []GTStructure
+func createGTReadFolder(directory string) []*GTStructure {
+	var items []*GTStructure
 	files, _ := ioutil.ReadDir(directory)
 
 	for _, f := range files {
-
-		var child GTStructure
+		child := &GTStructure{}
 		child.Name = f.Name()
 
 		if f.IsDir() {

--- a/gotree_test.go
+++ b/gotree_test.go
@@ -1,0 +1,57 @@
+package gotree
+
+import (
+	"testing"
+)
+
+// TestFolderTree should test if reading a folder returns rendered structure as expected
+func TestFolderTree(t *testing.T) {
+	tree := ReadFolder("test-resources")
+	actual := StringTree(tree)
+	expected := "test-resources\n" +
+		"├── dir1\n" +
+		"│   ├── dir3\n" +
+		"│   │   └── file2.txt\n" +
+		"│   └── file1.txt\n" +
+		"├── dir2\n" +
+		"│   └── file3.txt\n" +
+		"└── file4.txt\n"
+
+	if actual != expected {
+		t.Fatalf("Actual tree::\n[%s]\nis not the same as expected:\n[%s]", actual, expected)
+	}
+}
+
+// TestUpdatingItemsStructure should test whenever item updates in the tree structure are
+// reflected correctly in the rendered structure
+func TestUpdatingItemsStructure(t *testing.T) {
+	expected := "Pantera\n" +
+		"└── Far Beyond Driven\n" +
+		"    └── 5 minutes Alone\n"
+
+	var artist GTStructure
+	artist.Name = "Pantera Typo0"
+
+	var album GTStructure
+	album.Name = "Far Beyond Driven Typo1"
+
+	var music GTStructure
+	music.Name = "5 Minutes Alone Typo2"
+
+	// Add Music to the Album
+	album.Items = append(album.Items, &music)
+
+	// Add Album to the Artist
+	artist.Items = append(artist.Items, &album)
+
+	// apply updates to the items that are already in the tree structure
+	music.Name = "5 minutes Alone"
+	album.Name = "Far Beyond Driven"
+	artist.Name = "Pantera"
+
+	actual := StringTree(&artist)
+
+	if actual != expected {
+		t.Fatalf("Actual tree::\n[%s]\nis not the same as expected:\n[%s]", actual, expected)
+	}
+}

--- a/gotree_test.go
+++ b/gotree_test.go
@@ -4,24 +4,6 @@ import (
 	"testing"
 )
 
-// TestFolderTree should test if reading a folder returns rendered structure as expected
-func TestFolderTree(t *testing.T) {
-	tree := ReadFolder("test-resources")
-	actual := StringTree(tree)
-	expected := "test-resources\n" +
-		"├── dir1\n" +
-		"│   ├── dir3\n" +
-		"│   │   └── file2.txt\n" +
-		"│   └── file1.txt\n" +
-		"├── dir2\n" +
-		"│   └── file3.txt\n" +
-		"└── file4.txt\n"
-
-	if actual != expected {
-		t.Fatalf("Actual tree::\n[%s]\nis not the same as expected:\n[%s]", actual, expected)
-	}
-}
-
 // TestUpdatingItemsStructure should test whenever item updates in the tree structure are
 // reflected correctly in the rendered structure
 func TestUpdatingItemsStructure(t *testing.T) {


### PR DESCRIPTION
Updated GTStructure to use pointers to items instead of value receivers.
This is a breaking change as the public method signatures and main type has been modified.

- allows creation of the structure and flexible mutating it before actual printing
- pointer receiver should be more efficient for large data structures
- added simple test + test resources