### PR TITLE
Fix bug: last using invalid default value inside printText

### DIFF
--- a/gotree.go
+++ b/gotree.go
@@ -67,16 +67,14 @@ func (p *printer) Print(t Tree) string {
 	return t.Text() + newLine + p.printItems(t.Items(), []bool{})
 }
 
-func (p *printer) printText(text string, spaces []bool) string {
+func (p *printer) printText(text string, spaces []bool, last bool) string {
 	var result string
-	last := true
 	for _, space := range spaces {
 		if space {
 			result += emptySpace
 		} else {
 			result += continueItem
 		}
-		last = space
 	}
 
 	indicator := middleItem
@@ -91,7 +89,7 @@ func (p *printer) printItems(t []Tree, spaces []bool) string {
 	var result string
 	for i, f := range t {
 		last := i == len(t)-1
-		result += p.printText(f.Text(), spaces)
+		result += p.printText(f.Text(), spaces, last)
 		if len(f.Items()) > 0 {
 			spacesChild := append(spaces, last)
 			result += p.printItems(f.Items(), spacesChild)

--- a/gotree_test.go
+++ b/gotree_test.go
@@ -1,0 +1,26 @@
+package gotree_test
+
+import (
+	"testing"
+
+	gotree "github.com/DiSiqueira/GoTree"
+)
+
+func TestLast(t *testing.T) {
+	want := `Pantera
+├── Far Beyond Driven
+│   └── 5 minutes Alone
+└── Power Metal
+`
+
+	artist := gotree.New("Pantera")
+	album := artist.Add("Far Beyond Driven")
+	album.Add("5 minutes Alone")
+	artist.Add("Power Metal")
+
+	got := artist.Print()
+	if got != want {
+		t.Errorf("Expected: \n%s\n", want)
+		t.Errorf("Got: \n%s\n", got)
+	}
+}


### PR DESCRIPTION
Because of this incorrect indicator is selected. Pass last explicitly to
printText so it's value is used regardless of spaces.

Add a regression test.

---

Incorrect output because of this bug:

```
Pantera
└── Far Beyond Driven
│   ├── 5 minutes Alone
└── Power Metal
```

What it should be:

```
Pantera
├── Far Beyond Driven
│   └── 5 minutes Alone
└── Power Metal
```