### PR TITLE
redesign test, add godoc bange

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![GoTree](https://rawgit.com/DiSiqueira/GoTree/master/gotree-logo.png)
 
-# GoTree ![Language Badge](https://img.shields.io/badge/Language-Go-blue.svg) ![Go Report](https://goreportcard.com/badge/github.com/DiSiqueira/GoTree) ![License Badge](https://img.shields.io/badge/License-MIT-blue.svg) ![Status Badge](https://img.shields.io/badge/Status-Beta-brightgreen.svg)
+# GoTree ![Language Badge](https://img.shields.io/badge/Language-Go-blue.svg) ![Go Report](https://goreportcard.com/badge/github.com/DiSiqueira/GoTree) ![License Badge](https://img.shields.io/badge/License-MIT-blue.svg) ![Status Badge](https://img.shields.io/badge/Status-Beta-brightgreen.svg) [![GoDoc](https://godoc.org/github.com/DiSiqueira/GoTree?status.svg)](https://godoc.org/github.com/DiSiqueira/GoTree)
 
 Simple Go module to print tree structures in terminal. Heavily inpired by [The Tree Command for Linux][treecommand]
 

--- a/gotree_test.go
+++ b/gotree_test.go
@@ -1,26 +1,21 @@
 package gotree_test
 
 import (
-	"testing"
+	"fmt"
 
 	gotree "github.com/DiSiqueira/GoTree"
 )
 
-func TestLast(t *testing.T) {
-	want := `Pantera
-├── Far Beyond Driven
-│   └── 5 minutes Alone
-└── Power Metal
-`
-
+func ExampleTree() {
 	artist := gotree.New("Pantera")
 	album := artist.Add("Far Beyond Driven")
 	album.Add("5 minutes Alone")
 	artist.Add("Power Metal")
+	fmt.Println(artist.Print())
 
-	got := artist.Print()
-	if got != want {
-		t.Errorf("Expected: \n%s\n", want)
-		t.Errorf("Got: \n%s\n", got)
-	}
+	// Output:
+	// Pantera
+	// ├── Far Beyond Driven
+	// │   └── 5 minutes Alone
+	// └── Power Metal
 }


### PR DESCRIPTION
* refactoring test for better `godoc` view.
* add `godoc` bange

Go coverage is not changed:
```
go test -v -cover
=== RUN   ExampleTree
--- PASS: ExampleTree (0.00s)
PASS
coverage: 92.6% of statements
ok  	github.com/DiSiqueira/GoTree	
```