### PR TITLE
Refactor

### DIFF
--- a/gotree.go
+++ b/gotree.go
@@ -62,16 +62,24 @@ func (t *Tree) Print() string {
 }
 
 func Print(n Node) string {
-	return n.Text() + newLine + printItems(n.Items(), []bool{})
+	var out strings.Builder
+	printNode(&out, n)
+	return out.String()
 }
 
-func printText(text string, spaces []bool, last bool) string {
-	var result string
+func printNode(out *strings.Builder, n Node) {
+	out.WriteString(n.Text())
+	out.WriteString(newLine)
+	printItems(out, n.Items(), []bool{})
+}
+
+func printText(out *strings.Builder, text string, spaces []bool, last bool) {
+	var prefix string
 	for _, space := range spaces {
 		if space {
-			result += emptySpace
+			prefix += emptySpace
 		} else {
-			result += continueItem
+			prefix += continueItem
 		}
 	}
 
@@ -80,12 +88,11 @@ func printText(text string, spaces []bool, last bool) string {
 		indicator = lastItem
 	}
 
-	var out string
 	lines := strings.Split(text, "\n")
 	for i := range lines {
 		text := lines[i]
 		if i == 0 {
-			out += result + indicator + text + newLine
+			out.WriteString(prefix + indicator + text + newLine)
 			continue
 		}
 		if last {
@@ -93,20 +100,18 @@ func printText(text string, spaces []bool, last bool) string {
 		} else {
 			indicator = continueItem
 		}
-		out += result + indicator + text + newLine
+		out.WriteString(prefix + indicator + text + newLine)
 	}
-
-	return out
 }
 
-func printItems(t []Node, spaces []bool) string {
+func printItems(out *strings.Builder, t []Node, spaces []bool) string {
 	var result string
 	for i, f := range t {
 		last := i == len(t)-1
-		result += printText(f.Text(), spaces, last)
-		if len(f.Items()) > 0 {
+		printText(out, f.Text(), spaces, last)
+		if items := f.Items(); len(items) > 0 {
 			spacesChild := append(spaces, last)
-			result += printItems(f.Items(), spacesChild)
+			printItems(out, f.Items(), spacesChild)
 		}
 	}
 	return result

--- a/gotree.go
+++ b/gotree.go
@@ -26,11 +26,6 @@ type (
 		Items() []Tree
 		Text() string
 	}
-
-	// Printer is printer interface
-	Printer interface {
-		Print(Tree) string
-	}
 )
 
 // New returns a new GoTree.Tree

--- a/gotree.go
+++ b/gotree.go
@@ -14,57 +14,55 @@ const (
 )
 
 type (
-	tree struct {
+	Tree struct {
 		text  string
-		items []Tree
+		items []Node
 	}
 
-	// Tree is tree inteface
-	Tree interface {
-		Add(text string) Tree
-		AddTree(tree Tree)
-		Items() []Tree
+	// Node is tree inteface
+	Node interface {
+		Items() []Node
 		Text() string
 	}
 )
 
 // New returns a new GoTree.Tree
-func New(text string) Tree {
-	return &tree{
+func New(text string) *Tree {
+	return &Tree{
 		text:  text,
-		items: []Tree{},
+		items: []Node{},
 	}
 }
 
 // Add node in tree
-func (t *tree) Add(text string) Tree {
+func (t *Tree) Add(text string) *Tree {
 	n := New(text)
 	t.items = append(t.items, n)
 	return n
 }
 
-// AddTree is add tree in present tree
-func (t *tree) AddTree(tree Tree) {
-	t.items = append(t.items, tree)
+// AddNode is add tree in present tree
+func (t *Tree) AddNode(n Node) {
+	t.items = append(t.items, n)
 }
 
 // Text return text of root name
-func (t *tree) Text() string {
+func (t *Tree) Text() string {
 	return t.text
 }
 
 // Items return slice of tree nodes
-func (t *tree) Items() []Tree {
+func (t *Tree) Items() []Node {
 	return t.items
 }
 
 // Print return string of tree
-func (t *tree) Print() string {
+func (t *Tree) Print() string {
 	return Print(t)
 }
 
-func Print(t Tree) string {
-	return t.Text() + newLine + printItems(t.Items(), []bool{})
+func Print(n Node) string {
+	return n.Text() + newLine + printItems(n.Items(), []bool{})
 }
 
 func printText(text string, spaces []bool, last bool) string {
@@ -101,7 +99,7 @@ func printText(text string, spaces []bool, last bool) string {
 	return out
 }
 
-func printItems(t []Tree, spaces []bool) string {
+func printItems(t []Node, spaces []bool) string {
 	var result string
 	for i, f := range t {
 		last := i == len(t)-1

--- a/gotree.go
+++ b/gotree.go
@@ -25,7 +25,6 @@ type (
 		AddTree(tree Tree)
 		Items() []Tree
 		Text() string
-		Print() string
 	}
 
 	// Printer is printer interface

--- a/gotree.go
+++ b/gotree.go
@@ -28,9 +28,6 @@ type (
 		Print() string
 	}
 
-	printer struct {
-	}
-
 	// Printer is printer interface
 	Printer interface {
 		Print(Tree) string
@@ -69,18 +66,14 @@ func (t *tree) Items() []Tree {
 
 // Print return string of tree
 func (t *tree) Print() string {
-	return newPrinter().Print(t)
+	return Print(t)
 }
 
-func newPrinter() Printer {
-	return &printer{}
+func Print(t Tree) string {
+	return t.Text() + newLine + printItems(t.Items(), []bool{})
 }
 
-func (p *printer) Print(t Tree) string {
-	return t.Text() + newLine + p.printItems(t.Items(), []bool{})
-}
-
-func (p *printer) printText(text string, spaces []bool, last bool) string {
+func printText(text string, spaces []bool, last bool) string {
 	var result string
 	for _, space := range spaces {
 		if space {
@@ -114,14 +107,14 @@ func (p *printer) printText(text string, spaces []bool, last bool) string {
 	return out
 }
 
-func (p *printer) printItems(t []Tree, spaces []bool) string {
+func printItems(t []Tree, spaces []bool) string {
 	var result string
 	for i, f := range t {
 		last := i == len(t)-1
-		result += p.printText(f.Text(), spaces, last)
+		result += printText(f.Text(), spaces, last)
 		if len(f.Items()) > 0 {
 			spacesChild := append(spaces, last)
-			result += p.printItems(f.Items(), spacesChild)
+			result += printItems(f.Items(), spacesChild)
 		}
 	}
 	return result

--- a/gotree_test.go
+++ b/gotree_test.go
@@ -16,7 +16,7 @@ func ExampleTree() {
 
 	artist.Add("Power Metal\n(1988)")
 	artist.Add("Cowboys from Hell\n(1990)")
-	fmt.Println(artist.Print())
+	fmt.Println(gotree.Print(artist))
 
 	// Output:
 	// Pantera


### PR DESCRIPTION
* `Tree` interface doesn't provide anything useful.
* `Node` interface make it easier for external types to use `Print`.
* `Printer` interface wasn't used for anything.
* `printer` struct didn't serve any purpose.
* `strings.Builder` is much more efficient. 